### PR TITLE
Export loading card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shop-base-components",
-  "version": "2.1.61",
+  "version": "2.1.62",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studio-otto/shop-base-components",
-  "version": "2.1.61",
+  "version": "2.1.62",
   "description": "",
   "main": "dist/shop-base-components.ssr.js",
   "browser": "dist/shop-base-components.esm.js",

--- a/src/lib-components/index.js
+++ b/src/lib-components/index.js
@@ -2,6 +2,7 @@
 export { default as AnnouncementBar } from './announcement-bar.vue'
 export { default as CartTray } from './cart-tray/index.vue'
 export { default as CollectionProductCard } from './collection-product-card/index.vue'
+export { default as LoadingCard } from './collection-product-card/loading-card.vue'
 export { default as Modal } from './modal.vue'
 export { default as CookieConsent } from './cookie-consent.vue'
 export { default as LazyImage } from './lazy-image.vue'


### PR DESCRIPTION
Add in the loading card export for miaou. Regardless we are adding in these components, but in the case of miaou, I am modularly upgrading it to the base components so taht we can have the optimized loading and then add in configuration down the road for things like quickadd (could always just throw in a bunch of slots as well).